### PR TITLE
Fix client initialization & password policy handling

### DIFF
--- a/scripts/aws_iam_self_service_key_rotation.py
+++ b/scripts/aws_iam_self_service_key_rotation.py
@@ -31,16 +31,16 @@ console = Console()
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-# Session cache for performance
-_session = None
+# Cached IAM client for performance and easier mocking in tests
+_iam_client = None
 
 
 def get_iam_client():
-    """Get or create IAM client"""
-    global _session
-    if _session is None:
-        _session = boto3.Session()
-    return _session.client("iam")
+    """Return a boto3 IAM client, creating it if necessary."""
+    global _iam_client
+    if _iam_client is None:
+        _iam_client = boto3.client("iam")
+    return _iam_client
 
 
 def parse_args():

--- a/scripts/aws_iam_self_service_password_reset.py
+++ b/scripts/aws_iam_self_service_password_reset.py
@@ -105,8 +105,8 @@ def validate_password_policy(password):
 
         return errors
 
-    except ClientError:
-        # If we can't get the password policy, assume basic requirements
+    except (ClientError, NoCredentialsError, PartialCredentialsError):
+        # If policy cannot be retrieved (e.g., no credentials), fall back to basic checks
         logger.warning("Could not retrieve password policy, using default validation")
         errors = []
         if len(password) < 8:


### PR DESCRIPTION
## Summary
- lazily initialize boto3 clients so tests can patch them
- speed up credential report polling
- handle missing credentials in password policy validation

## Testing
- `black .`
- `flake8 scripts/ lambda/ tests/ --max-line-length=120 --ignore=E501,W503,E203`
- `mypy --ignore-missing-imports scripts/ lambda/`
- `bandit -r scripts/ lambda/`
- `python tests/run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_685f226e43a88332a61370a2805accf1

## Summary by Sourcery

Improve AWS client initialization, accelerate credential report polling, and handle missing credentials in password policy validation.

Bug Fixes:
- Fallback to default password policy validation when AWS credentials are missing or partial.

Enhancements:
- Lazy-initialize boto3 clients (IAM, SES, CloudWatch) to facilitate mocking in tests
- Shorten sleep interval in credential report polling to speed up report generation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved AWS client initialization across multiple scripts for more efficient and reliable usage.
  * Simplified client caching logic in key rotation script for better maintainability.

* **Bug Fixes**
  * Enhanced error handling in password policy validation to cover missing or incomplete AWS credentials.

* **Performance**
  * Reduced waiting time when generating IAM credential reports, resulting in faster operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->