### PR TITLE
Add mocks to tests

### DIFF
--- a/tests/integration/test_iam_integration.py
+++ b/tests/integration/test_iam_integration.py
@@ -336,15 +336,15 @@ class TestAWSIAMComplianceReport(unittest.TestCase):
         )
         csv_row1 = (
             'testuser,"arn:aws:iam::000000000000:user/testuser",2023-01-01T00:00:00Z,'
-            'true,2024-01-01T00:00:00Z,2023-01-01T00:00:00Z,N/A,true,true,'
+            "true,2024-01-01T00:00:00Z,2023-01-01T00:00:00Z,N/A,true,true,"
             '2023-01-01T00:00:00Z,2024-01-01T00:00:00Z,"us-east-1,us-west-2",s3,'
-            'false,N/A,N/A,N/A,N/A'
+            "false,N/A,N/A,N/A,N/A"
         )
         csv_row2 = (
             '"user,with,commas","arn:aws:iam::000000000000:user/user,with,commas",'
-            '2023-01-01T00:00:00Z,true,2024-01-01T00:00:00Z,2023-01-01T00:00:00Z,N/A,'
-            'false,true,2023-01-01T00:00:00Z,2024-01-01T00:00:00Z,eu-west-1,ec2,'
-            'false,N/A,N/A,N/A,N/A'
+            "2023-01-01T00:00:00Z,true,2024-01-01T00:00:00Z,2023-01-01T00:00:00Z,N/A,"
+            "false,true,2023-01-01T00:00:00Z,2024-01-01T00:00:00Z,eu-west-1,ec2,"
+            "false,N/A,N/A,N/A,N/A"
         )
         csv_content = f"{csv_header}\n{csv_row1}\n{csv_row2}\n"
 

--- a/tests/test_compliance_report.py
+++ b/tests/test_compliance_report.py
@@ -329,35 +329,35 @@ class TestArgumentParsing(unittest.TestCase):
         with patch("sys.argv", ["script"]):
             args = compliance.parse_args()
 
-        self.assertEqual(args.format, "table")
-        self.assertIsNone(args.export)
-        self.assertFalse(args.json)
-        self.assertFalse(args.csv)
+        self.assertIsNone(args.csv)
+        self.assertIsNone(args.json)
+        self.assertFalse(args.summary_only)
+        self.assertFalse(args.quiet)
 
-    def test_parse_args_json_format(self):
-        """Test JSON format argument"""
-        with patch("sys.argv", ["script", "--json"]):
+    def test_parse_args_json_flag(self):
+        """Test JSON export argument"""
+        with patch("sys.argv", ["script", "--json", "report.json"]):
             args = compliance.parse_args()
 
-        self.assertTrue(args.json)
-        self.assertFalse(args.csv)
+        self.assertEqual(args.json, "report.json")
+        self.assertIsNone(args.csv)
 
-    def test_parse_args_export(self):
-        """Test export argument"""
-        with patch("sys.argv", ["script", "--export", "report.json"]):
+    def test_parse_args_csv_export(self):
+        """Test CSV export argument"""
+        with patch("sys.argv", ["script", "--csv", "report.csv"]):
             args = compliance.parse_args()
 
-        self.assertEqual(args.export, "report.json")
+        self.assertEqual(args.csv, "report.csv")
 
-    def test_parse_args_format_and_export(self):
-        """Test combined format and export arguments"""
+    def test_parse_args_csv_and_json(self):
+        """Test combined CSV and JSON export arguments"""
         with patch(
-            "sys.argv", ["script", "--format", "csv", "--export", "report.csv"]
+            "sys.argv", ["script", "--csv", "report.csv", "--json", "report.json"]
         ):
             args = compliance.parse_args()
 
-        self.assertEqual(args.format, "csv")
-        self.assertEqual(args.export, "report.csv")
+        self.assertEqual(args.csv, "report.csv")
+        self.assertEqual(args.json, "report.json")
 
 
 class TestMainFunction(unittest.TestCase):
@@ -369,10 +369,10 @@ class TestMainFunction(unittest.TestCase):
         """Test main with table display"""
         # Mock arguments
         mock_args = Mock()
-        mock_args.format = "table"
-        mock_args.json = False
-        mock_args.csv = False
-        mock_args.export = None
+        mock_args.json = None
+        mock_args.csv = None
+        mock_args.summary_only = False
+        mock_args.quiet = False
         mock_parse_args.return_value = mock_args
 
         # Mock report instance
@@ -394,10 +394,10 @@ class TestMainFunction(unittest.TestCase):
         """Test main with JSON export"""
         # Mock arguments
         mock_args = Mock()
-        mock_args.format = "json"
-        mock_args.json = True
-        mock_args.csv = False
-        mock_args.export = "report.json"
+        mock_args.json = "report.json"
+        mock_args.csv = None
+        mock_args.summary_only = False
+        mock_args.quiet = False
         mock_parse_args.return_value = mock_args
 
         # Mock report instance
@@ -420,10 +420,10 @@ class TestMainFunction(unittest.TestCase):
         """Test main with error handling"""
         # Mock arguments
         mock_args = Mock()
-        mock_args.format = "table"
-        mock_args.json = False
-        mock_args.csv = False
-        mock_args.export = None
+        mock_args.json = None
+        mock_args.csv = None
+        mock_args.summary_only = False
+        mock_args.quiet = False
         mock_parse_args.return_value = mock_args
 
         # Mock report instance to raise error

--- a/tests/test_lambda_enforcement.py
+++ b/tests/test_lambda_enforcement.py
@@ -10,6 +10,9 @@ import os
 import json
 from datetime import datetime, timedelta
 
+# Ensure boto3 client creation does not fail due to missing region
+os.environ.setdefault("AWS_DEFAULT_REGION", "us-east-1")
+
 # Add the lambda directory to the path
 sys.path.insert(
     0, os.path.join(os.path.dirname(__file__), "..", "lambda", "access_key_enforcement")
@@ -93,7 +96,8 @@ class TestLambdaHandler(unittest.TestCase):
         },
     )
     @patch("access_key_enforcement.iam_client")
-    def test_lambda_handler_credential_report_timeout(self, mock_iam):
+    @patch("access_key_enforcement.time.sleep")
+    def test_lambda_handler_credential_report_timeout(self, mock_sleep, mock_iam):
         """Test Lambda execution when credential report generation times out"""
         # Mock credential report generation
         mock_iam.generate_credential_report.return_value = {}

--- a/tests/test_password_reset.py
+++ b/tests/test_password_reset.py
@@ -18,16 +18,26 @@ import aws_iam_self_service_password_reset as pwd_reset  # noqa: E402
 class TestPasswordGeneration(unittest.TestCase):
     """Test password generation functionality"""
 
-    def test_passwordgen_length(self):
+    @patch("aws_iam_self_service_password_reset.boto3.client")
+    def test_passwordgen_length(self, mock_boto_client):
         """Test that generated passwords have correct length"""
+        mock_client = Mock()
+        mock_boto_client.return_value = mock_client
+        mock_client.get_account_password_policy.return_value = {"PasswordPolicy": {}}
+
         password = pwd_reset.passwordgen(20)
         self.assertEqual(len(password), 20)
 
         password = pwd_reset.passwordgen(30)
         self.assertEqual(len(password), 30)
 
-    def test_passwordgen_character_requirements(self):
+    @patch("aws_iam_self_service_password_reset.boto3.client")
+    def test_passwordgen_character_requirements(self, mock_boto_client):
         """Test that generated passwords meet character requirements"""
+        mock_client = Mock()
+        mock_boto_client.return_value = mock_client
+        mock_client.get_account_password_policy.return_value = {"PasswordPolicy": {}}
+
         password = pwd_reset.passwordgen(20)
 
         # Check for uppercase letters
@@ -42,16 +52,26 @@ class TestPasswordGeneration(unittest.TestCase):
         # Check for symbols
         self.assertTrue(any(c in "!@#$%^&*()_+-=[]{}|;:,.<>?" for c in password))
 
-    def test_passwordgen_excludes_ambiguous(self):
+    @patch("aws_iam_self_service_password_reset.boto3.client")
+    def test_passwordgen_excludes_ambiguous(self, mock_boto_client):
         """Test that ambiguous characters are excluded when requested"""
+        mock_client = Mock()
+        mock_boto_client.return_value = mock_client
+        mock_client.get_account_password_policy.return_value = {"PasswordPolicy": {}}
+
         password = pwd_reset.passwordgen(50, exclude_ambiguous=True)
         ambiguous = "0O1lI"
 
         for char in ambiguous:
             self.assertNotIn(char, password)
 
-    def test_passwordgen_uniqueness(self):
+    @patch("aws_iam_self_service_password_reset.boto3.client")
+    def test_passwordgen_uniqueness(self, mock_boto_client):
         """Test that multiple calls generate different passwords"""
+        mock_client = Mock()
+        mock_boto_client.return_value = mock_client
+        mock_client.get_account_password_policy.return_value = {"PasswordPolicy": {}}
+
         passwords = [pwd_reset.passwordgen(20) for _ in range(10)]
 
         # All passwords should be unique

--- a/tests/test_user_cleanup.py
+++ b/tests/test_user_cleanup.py
@@ -121,6 +121,12 @@ class TestDeleteLoginProfile(unittest.TestCase):
     def test_delete_login_profile_error(self, mock_print, mock_client):
         """Test login profile deletion with error"""
         mock_client.delete_login_profile.side_effect = Exception("Access denied")
+        # Ensure NoSuchEntityException attribute exists and is a proper Exception
+        mock_client.exceptions.NoSuchEntityException = type(
+            "NoSuchEntityException",
+            (Exception,),
+            {},
+        )
 
         result = cleanup.delete_login_profile("testuser")
 


### PR DESCRIPTION
## Summary
- fix user cleanup test for proper exception type
- update compliance report CLI tests for current args
- set AWS region for lambda tests
- mock boto3 in password reset generator tests

## Testing
- `black tests/test_user_cleanup.py tests/test_compliance_report.py tests/test_lambda_enforcement.py tests/test_password_reset.py tests/integration/test_iam_integration.py`
- `flake8 scripts/ lambda/ tests/ --max-line-length=120 --ignore=E501,W503,E203`
- `mypy scripts/ lambda/ --ignore-missing-imports`
- `bandit -r scripts/ lambda/`
- `python tests/run_tests.py` *(fails: NoCredentialsError)*

------
https://chatgpt.com/codex/tasks/task_e_68633ca855048332952e25a0d7ec5218

## Summary by Sourcery

Update tests to mock AWS dependencies, adapt to new CLI flags, and improve error simulation

Enhancements:
- Adapt compliance report tests to new --json and --csv flags and validate default summary_only and quiet options
- Mock boto3 client in password reset tests to isolate AWS calls
- Stub NoSuchEntityException in user cleanup test to ensure proper exception handling
- Patch time.sleep in lambda enforcement tests to simulate credential report timeouts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated tests to reflect changes in command-line argument handling, now supporting explicit `--json` and `--csv` export options.
  * Improved test isolation by mocking AWS clients and environment variables to prevent external dependencies and configuration errors.
  * Enhanced test reliability by mocking time delays and AWS exceptions.
  * Minor style adjustments to string literals in test data for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->