### PR TITLE
Update README security comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ coverage html  # Generate HTML report
 bandit -r scripts/ lambda/
 
 # Check for hardcoded secrets
-pytest -m integration --collect-only  # Triggers security fixtures
+pytest -m integration --collect-only  # Lists integration tests without executing them or their fixtures
 ```
 
 ### 🏗️ CI/CD Pipeline


### PR DESCRIPTION
## Summary
- clarify how `--collect-only` works during integration test invocation

## Testing
- `None`

------
https://chatgpt.com/codex/tasks/task_e_6865ea9468f88332b142728a68d4439f

## Summary by Sourcery

Documentation:
- Clarify in README that pytest --collect-only lists integration tests without executing them or their fixtures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified the description for the `pytest -m integration --collect-only` command to accurately reflect that it lists integration tests without executing them or their fixtures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->