### PR TITLE
Expand moto-backed coverage and infrastructure validation

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,2 @@
+[mypy]
+ignore_missing_imports = True

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,14 +3,16 @@ testpaths = tests
 python_files = test_*.py
 python_classes = Test*
 python_functions = test_*
-addopts = 
+addopts =
     -v
     --tb=short
     --strict-markers
     --cov=scripts
+    --cov=lambda
     --cov-report=term-missing
     --cov-report=html
     --cov-report=xml
+    --cov-fail-under=85
 markers =
     integration: Integration tests that may require AWS mocking
     unit: Unit tests for individual functions

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -13,3 +13,4 @@ moto>=4.2.0
 mypy
 flake8
 black
+bandit>=1.7.0

--- a/tests/integration/test_cli_end_to_end.py
+++ b/tests/integration/test_cli_end_to_end.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""End-to-end style CLI tests executed against moto-backed AWS services."""
+
+import io
+import json
+import os
+import runpy
+import sys
+from contextlib import redirect_stdout
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+import boto3
+import pytest
+from moto import mock_aws
+
+
+def _scripts_path(script_name: str) -> Path:
+    return Path(__file__).resolve().parents[2] / "scripts" / script_name
+
+
+@pytest.mark.integration
+def test_key_rotation_list_json_cli():
+    """Invoke the key rotation CLI and validate the JSON payload it prints."""
+
+    script = _scripts_path("aws_iam_self_service_key_rotation.py")
+
+    class _FakeIAM:
+        def list_access_keys(self):
+            return {
+                "AccessKeyMetadata": [
+                    {
+                        "AccessKeyId": "AKIAFAKE1234567890",
+                        "Status": "Active",
+                        "CreateDate": datetime.now(timezone.utc),
+                    }
+                ]
+            }
+
+    stdout = io.StringIO()
+    argv = [script.name, "--list", "--json"]
+
+    with patch.object(sys, "argv", argv):
+        with patch("boto3.client", return_value=_FakeIAM()):
+            with redirect_stdout(stdout):
+                runpy.run_path(script, run_name="__main__")
+
+    payload = json.loads(stdout.getvalue())
+    assert payload["AccessKeys"][0]["AccessKeyId"] == "AKIAFAKE1234567890"
+
+
+@pytest.mark.integration
+def test_password_reset_list_users_cli():
+    """Ensure the password reset CLI lists users without raising errors."""
+
+    script = _scripts_path("aws_iam_user_password_reset.py")
+
+    with mock_aws():
+        os.environ.setdefault("AWS_DEFAULT_REGION", "us-east-1")
+        os.environ.setdefault("AWS_ACCESS_KEY_ID", "testing")
+        os.environ.setdefault("AWS_SECRET_ACCESS_KEY", "testing")
+
+        iam = boto3.client("iam", region_name="us-east-1")
+        iam.create_user(UserName="cli-user-one")
+        iam.create_user(UserName="cli-user-two")
+
+        stdout = io.StringIO()
+        argv = [script.name, "list-users"]
+
+        with patch.object(sys, "argv", argv):
+            with redirect_stdout(stdout):
+                runpy.run_path(script, run_name="__main__")
+
+    output = stdout.getvalue().splitlines()
+    assert "Found 2 IAM users:" in output[0]
+    assert any(line.strip().endswith("cli-user-one") for line in output)
+    assert any(line.strip().endswith("cli-user-two") for line in output)

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -4,3 +4,4 @@ pytest-cov>=4.0.0
 pytest-mock>=3.10.0
 moto>=4.0.0  # AWS service mocking
 coverage>=7.0.0
+types-python-dateutil>=2.8.19

--- a/tests/test_compliance_report.py
+++ b/tests/test_compliance_report.py
@@ -200,6 +200,16 @@ class TestIAMComplianceReport(unittest.TestCase):
         result = report.parse_date("not_supported")
         self.assertIsNone(result)
 
+    def test_parse_credential_report_skips_incomplete_rows(self):
+        """Regression guard to ensure malformed CSV rows are ignored safely."""
+
+        report = compliance.IAMComplianceReport()
+
+        csv_data = "header1,header2\ninvalid_row_without_enough_columns\n"
+        report.parse_credential_report(csv_data)
+
+        self.assertEqual(report.users_data, [])
+
     def test_calculate_age_days_valid(self):
         """Test age calculation with valid date"""
         report = compliance.IAMComplianceReport()

--- a/tests/test_password_notification_lambda.py
+++ b/tests/test_password_notification_lambda.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Tests for the password notification Lambda using moto-backed AWS services."""
+
+import importlib
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Iterator
+
+import boto3
+import pytest
+from moto import mock_aws
+
+
+@pytest.fixture()
+def password_notification_module() -> Iterator[object]:
+    """Load the Lambda module with moto-backed boto3 clients."""
+
+    module_path = (
+        Path(__file__).resolve().parent.parent / "lambda" / "password_notification"
+    )
+    sys.path.insert(0, str(module_path))
+
+    with mock_aws():
+        os.environ.setdefault("AWS_ACCESS_KEY_ID", "testing")
+        os.environ.setdefault("AWS_SECRET_ACCESS_KEY", "testing")
+        os.environ.setdefault("AWS_DEFAULT_REGION", "us-east-1")
+
+        module = importlib.import_module("password_notification")
+        module = importlib.reload(module)
+
+        # Replace the global clients with moto-backed instances for deterministic tests
+        module.iam_client = boto3.client("iam", region_name="us-east-1")
+        module.ses_client = boto3.client("ses", region_name="us-east-1")
+        module.ses_client.verify_email_identity(
+            EmailAddress="cloud-admins@jennasrunbooks.com"
+        )
+
+        try:
+            yield module
+        finally:
+            sys.path.remove(str(module_path))
+            sys.modules.pop("password_notification", None)
+
+
+def _credential_report_for(users: list[tuple[str, datetime]]):
+    """Generate a credential report CSV for the provided users."""
+
+    rows = [
+        "user,arn,user_creation_time,password_enabled,password_last_used,password_last_changed",
+    ]
+    for username, changed_at in users:
+        rows.append(
+            ",".join(
+                [
+                    username,
+                    f"arn:aws:iam::123456789012:user/{username}",
+                    "2023-01-01T00:00:00+00:00",
+                    "true",
+                    "N/A",
+                    changed_at.astimezone(timezone.utc).isoformat(),
+                ]
+            )
+        )
+    return "\n".join(rows).encode("utf-8")
+
+
+def test_lambda_sends_notifications_for_expiring_passwords(
+    password_notification_module,
+):
+    """Verify that users beyond the warning threshold receive an email."""
+
+    module = password_notification_module
+    iam_client = module.iam_client
+
+    iam_client.create_user(UserName="alice")
+    iam_client.tag_user(
+        UserName="alice", Tags=[{"Key": "email", "Value": "alice@example.com"}]
+    )
+
+    iam_client.create_user(UserName="bob")
+    iam_client.tag_user(
+        UserName="bob", Tags=[{"Key": "email", "Value": "bob@example.com"}]
+    )
+
+    expiring = datetime.now(timezone.utc) - timedelta(days=80)
+    recent = datetime.now(timezone.utc) - timedelta(days=5)
+    credential_data = _credential_report_for([("alice", expiring), ("bob", recent)])
+
+    # First call during the wait loop and second call when processing
+    responses = [{"Content": credential_data}, {"Content": credential_data}]
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(module.time, "sleep", lambda *_: None)
+        mp.setattr(module.iam_client, "get_credential_report", lambda: responses.pop(0))
+
+        with pytest.MonkeyPatch.context() as nested_mp:
+            original_send = module.ses_client.send_email
+            send_calls = []
+
+            def _send_email(**kwargs):
+                send_calls.append(kwargs)
+                return original_send(**kwargs)
+
+            nested_mp.setattr(module.ses_client, "send_email", _send_email)
+
+            result = module.lambda_handler({}, None)
+
+    assert result == "Password expiry notifications sent."
+    assert len(send_calls) == 1
+    assert send_calls[0]["Destination"]["ToAddresses"] == ["alice@example.com"]
+
+
+def test_lambda_skips_users_without_emails(password_notification_module):
+    """Ensure the Lambda tolerates users without email tags gracefully."""
+
+    module = password_notification_module
+    iam_client = module.iam_client
+
+    iam_client.create_user(UserName="no-email-user")
+
+    aged = datetime.now(timezone.utc) - timedelta(days=120)
+    credential_data = _credential_report_for([("no-email-user", aged)])
+    responses = [{"Content": credential_data}, {"Content": credential_data}]
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(module.time, "sleep", lambda *_: None)
+        mp.setattr(module.iam_client, "get_credential_report", lambda: responses.pop(0))
+
+        with pytest.MonkeyPatch.context() as nested_mp:
+            nested_mp.setattr(
+                module.ses_client,
+                "send_email",
+                lambda **_: pytest.fail("Email should not be sent"),
+            )
+
+            result = module.lambda_handler({}, None)
+
+    assert result == "Password expiry notifications sent."

--- a/tests/test_secret_key_rotation_s3.py
+++ b/tests/test_secret_key_rotation_s3.py
@@ -1,14 +1,20 @@
 #!/usr/bin/env python3
 """Unit tests for secret key rotation and S3 storage."""
 
+import os
+import runpy
+import sys
+import types
 import unittest
-from unittest.mock import Mock, patch, ANY
 from datetime import datetime
+from pathlib import Path
+from unittest.mock import ANY, Mock, patch
+
+import boto3
+from botocore.exceptions import ClientError
+from moto import mock_aws
 
 # Add scripts directory to path
-import os
-import sys
-
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
 
 import aws_iam_secret_key_rotation_s3 as rotate  # noqa: E402
@@ -54,6 +60,129 @@ class TestRotateAndStoreCredentials(unittest.TestCase):
         iam.update_access_key.assert_called_once_with(
             UserName="test", AccessKeyId="OLD", Status="Inactive"
         )
+
+    def test_rotate_and_store_with_moto(self):
+        rotate._iam_client = None
+        rotate._s3_client = None
+
+        with mock_aws():
+            iam = boto3.client("iam", region_name="us-east-1")
+            s3 = boto3.client("s3", region_name="us-east-1")
+
+            iam.create_user(UserName="demo-user")
+            iam.create_access_key(UserName="demo-user")
+
+            with patch("builtins.print"):
+                url = rotate.rotate_and_store_credentials("demo-user")
+
+            buckets = s3.list_buckets()["Buckets"]
+            self.assertTrue(buckets)
+            self.assertTrue(url.startswith("https://"))
+
+    def test_cli_invocation_executes_rotation(self):
+        script = (
+            Path(__file__).resolve().parents[1]
+            / "scripts"
+            / "aws_iam_secret_key_rotation_s3.py"
+        )
+
+        class _FakeIAM:
+            def __init__(self):
+                self.calls = []
+
+            def list_access_keys(self, UserName):
+                self.calls.append(("list", UserName))
+                return {"AccessKeyMetadata": []}
+
+            def create_access_key(self, UserName):
+                self.calls.append(("create", UserName))
+                return {
+                    "AccessKey": {
+                        "AccessKeyId": "FAKE",
+                        "SecretAccessKey": "SECRET",
+                        "CreateDate": datetime(2024, 1, 1),
+                    }
+                }
+
+            def update_access_key(self, **kwargs):
+                self.calls.append(("update", kwargs))
+
+        class _FakeS3:
+            def create_bucket(self, **kwargs):
+                pass
+
+            def put_public_access_block(self, **kwargs):
+                pass
+
+            def put_object(self, **kwargs):
+                pass
+
+            def generate_presigned_url(self, *_, **__):
+                return "https://example.com"
+
+        class _FakeBoto3:
+            def __init__(self):
+                self.iam = _FakeIAM()
+                self.s3 = _FakeS3()
+
+            def client(self, name, **_):
+                return self.iam if name == "iam" else self.s3
+
+        fake_boto3 = _FakeBoto3()
+        fake_module = types.ModuleType("boto3")
+        fake_module.client = fake_boto3.client
+
+        with patch.object(sys, "argv", [script.name, "demo"]):
+            with patch("builtins.print"):
+                with patch.dict(sys.modules, {"boto3": fake_module}):
+                    runpy.run_path(script, run_name="__main__")
+
+        self.assertIn(("list", "demo"), fake_boto3.iam.calls)
+        self.assertTrue(any(call[0] == "create" for call in fake_boto3.iam.calls))
+
+    def test_cli_propagates_client_errors(self):
+        script = (
+            Path(__file__).resolve().parents[1]
+            / "scripts"
+            / "aws_iam_secret_key_rotation_s3.py"
+        )
+
+        class _ErroringIAM:
+            def list_access_keys(self, UserName):
+                return {"AccessKeyMetadata": []}
+
+            def create_access_key(self, UserName):
+                raise ClientError(
+                    {"Error": {"Code": "AccessDenied", "Message": "denied"}},
+                    "CreateAccessKey",
+                )
+
+        class _NoopS3:
+            def create_bucket(self, **kwargs):
+                pass
+
+            def put_public_access_block(self, **kwargs):
+                pass
+
+        class _FakeBoto3:
+            def __init__(self):
+                self.iam = _ErroringIAM()
+                self.s3 = _NoopS3()
+
+            def client(self, name, **_):
+                return self.iam if name == "iam" else self.s3
+
+        fake_boto3 = _FakeBoto3()
+        fake_module = types.ModuleType("boto3")
+        fake_module.client = fake_boto3.client
+
+        with patch.object(sys, "argv", [script.name, "demo"]):
+            with patch.dict(sys.modules, {"boto3": fake_module}):
+                with self.assertLogs(level="ERROR") as logs:
+                    with self.assertRaises(ClientError):
+                        runpy.run_path(script, run_name="__main__")
+
+        self.assertTrue(any("AWS error" in message for message in logs.output))
 
 
 if __name__ == "__main__":

--- a/tests/test_terraform_validation.py
+++ b/tests/test_terraform_validation.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Lightweight infrastructure validation executed during the test suite."""
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+TERRAFORM_ROOT = Path(__file__).resolve().parents[1] / "terraform" / "iam"
+
+
+def _run_terraform_command(work_dir: Path, *args: str) -> subprocess.CompletedProcess:
+    env = os.environ.copy()
+    env.setdefault("TF_IN_AUTOMATION", "1")
+
+    result = subprocess.run(
+        ["terraform", *args],
+        cwd=work_dir,
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    if result.returncode != 0:
+        stderr = result.stderr or ""
+        provider_errors = (
+            "Failed to query available provider packages" in stderr
+            or "Failed to install provider" in stderr
+            or "Could not connect to" in stderr
+        )
+        if provider_errors:
+            pytest.skip("Terraform providers are unavailable in the test environment")
+
+    return result
+
+
+@pytest.mark.integration
+def test_terraform_configuration_validates(tmp_path):
+    """Copy the Terraform configuration and ensure it validates cleanly."""
+
+    if shutil.which("terraform") is None:
+        pytest.skip("Terraform CLI is not installed")
+
+    work_dir = tmp_path / "terraform" / "iam"
+    shutil.copytree(TERRAFORM_ROOT, work_dir)
+
+    init_result = _run_terraform_command(
+        work_dir, "init", "-backend=false", "-input=false"
+    )
+    if init_result.returncode != 0:
+        pytest.fail(f"terraform init failed: {init_result.stderr}")
+
+    validate_result = _run_terraform_command(work_dir, "validate", "-no-color")
+    if validate_result.returncode != 0:
+        pytest.fail(f"terraform validate failed: {validate_result.stderr}")


### PR DESCRIPTION
## Summary
- add moto-backed unit coverage for the password notification Lambda and expand password reset/secret rotation CLI regression tests
- introduce CLI end-to-end checks, Terraform validation, and stricter pytest coverage thresholds
- update tooling requirements with typing and security extras plus repository-wide mypy configuration

## Testing
- black .
- flake8 scripts/ lambda/ tests/ --max-line-length=120 --ignore=E501,W503,E203
- mypy --config-file mypy.ini scripts/ lambda/
- bandit -r scripts/ lambda/
- pytest
- pytest tests/integration --no-cov

------
https://chatgpt.com/codex/tasks/task_e_68cc1b444a34833294619cb0df8e9442

## Summary by Sourcery

Expand and strengthen testing coverage and validation infrastructure, and update tooling requirements and static typing configuration.

Enhancements:
- Enforce stricter pytest coverage thresholds and extend coverage measurement to lambda directory

Tests:
- Add moto-backed unit tests for the password notification Lambda, secret key rotation S3 script, and CLI password reset main workflow
- Introduce integration tests for CLI end-to-end flows (key rotation and user listing) and Terraform configuration validation
- Add a regression test to ensure malformed CSV rows are safely skipped by the compliance report parser
- Update pytest configuration to include lambda code in coverage and enforce an 85% coverage threshold

Chores:
- Introduce a repository-wide mypy configuration and update tooling requirements (mypy, typing, and security extras)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Tests
  - Added end-to-end CLI tests and moto-backed integration tests for IAM key rotation, password reset, and password notification workflows.
  - Introduced Terraform configuration validation test.
  - Added regression test ensuring malformed credential report rows are ignored.
  - Expanded coverage for S3 credential rotation and error handling.

- Chores
  - Added static type checking configuration; relaxed missing-import checks.
  - Enforced minimum 85% test coverage via pytest configuration.
  - Introduced security linter dependency (Bandit) for scripts.
  - Added typing stubs for dateutil in test dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->